### PR TITLE
Fix HTML validity errors in the Mozilla planet output

### DIFF
--- a/filters/addsearch.xslt
+++ b/filters/addsearch.xslt
@@ -2,6 +2,11 @@
                 xmlns:xhtml="http://www.w3.org/1999/xhtml"
                 xmlns="http://www.w3.org/1999/xhtml">
 
+  <!-- Match the serialization of index.html.xslt: XML output with no XML
+       declaration. Without this, libxslt prepends "<?xml version='1.0'?>" to
+       the page, a forbidden processing instruction in a text/html document. -->
+  <xsl:output method="xml" omit-xml-declaration="yes" encoding="utf-8"/>
+
   <!-- insert search form -->
   <xsl:template match="xhtml:div[@id='sidebar']">
     <xsl:copy>

--- a/themes/mozilla/index.html.xslt
+++ b/themes/mozilla/index.html.xslt
@@ -70,22 +70,10 @@
           <xsl:for-each select='atom:entry'>
             <article class="post feed-{atom:source/planet:css-id}">
 
-              <xsl:if test="@xml:lang">
-                <xsl:attribute name="xml:lang">
-                  <xsl:value-of select="@xml:lang"/>
-                </xsl:attribute>
-              </xsl:if>
-
               <!-- Entry header -->
               <header>
                 <p>
                   <span class="label">
-                    <xsl:if test="atom:source/atom:link[@rel='alternate']/@href">
-                      <xsl:attribute name="href">
-                        <xsl:value-of
-                          select="atom:source/atom:link[@rel='alternate']/@href"/>
-                      </xsl:attribute>
-                    </xsl:if>
                     <xsl:attribute name="title">
                       <xsl:value-of select="atom:source/atom:title"/>
                     </xsl:attribute>
@@ -97,9 +85,6 @@
                 <h3 class="post-title">
                   <xsl:if test="string-length(atom:title) &gt; 0">
                     <a href="{atom:link[@rel='alternate']/@href}">
-                      <xsl:if test="atom:title/@xml:lang != @xml:lang">
-                        <xsl:attribute name="xml:lang" select="{atom:title/@xml:lang}"/>
-                      </xsl:if>
                       <xsl:value-of select="atom:title"/>
                     </a>
                   </xsl:if>
@@ -127,7 +112,7 @@
                       <xsl:text> on </xsl:text>
                     </xsl:when>
                   </xsl:choose>
-                  <time datetime="substring(atom:updated,1,10)">
+                  <time datetime="{substring(atom:updated,1,10)}">
                     <xsl:value-of select="atom:updated/@planet:format"/>
                   </time>
                 </p>
@@ -173,7 +158,6 @@
                   <a href='rss10.xml'>RSS 1.0</a>
                 </li>
               </ul>
-              <p/>
               <p>Subscription list:</p>
               <ul class="menu vertical">
                 <li class="menu-item">
@@ -265,10 +249,6 @@
                         <xsl:if test="string-length(atom:title) &gt; 0">
                           <li>
                             <a href="{atom:link[@rel='alternate']/@href}">
-                              <xsl:if test="atom:title/@xml:lang != @xml:lang">
-                                <xsl:attribute name="xml:lang"
-                                  select="{atom:title/@xml:lang}"/>
-                              </xsl:if>
                               <xsl:value-of select="atom:title"/>
                             </a>
                           </li>
@@ -280,12 +260,12 @@
               </xsl:for-each>
             </ul>
           </div>
-          <div class='bottom'></div>
-        </div>
+          <div class='bottom'><xsl:comment>empty element</xsl:comment></div>
 
-        <div id='footer'>
-          <div id='footer-content'>
-            <p>Maintained by the <a href='https://bugzilla.mozilla.org/enter_bug.cgi?product=Websites&amp;component=planet.mozilla.org'>Planet Mozilla Module Team</a>. Powered by <a href='http://www.intertwingly.net/code/venus/'>Planet Venus</a>. View our <a href='https://www.mozilla.org/about/policies/privacy-policy.html'>Privacy Policy</a>.</p>
+          <div id='footer'>
+            <div id='footer-content'>
+              <p>Maintained by the <a href='https://bugzilla.mozilla.org/enter_bug.cgi?product=Websites&amp;component=planet.mozilla.org'>Planet Mozilla Module Team</a>. Powered by <a href='http://www.intertwingly.net/code/venus/'>Planet Venus</a>. View our <a href='https://www.mozilla.org/about/policies/privacy-policy.html'>Privacy Policy</a>.</p>
+            </div>
           </div>
         </div>
       </div>
@@ -298,11 +278,6 @@
   <!-- xhtml content -->
   <xsl:template match='atom:content/xhtml:div | atom:summary/xhtml:div'>
     <xsl:copy>
-      <xsl:if test='../@xml:lang and not(../@xml:lang = ../../@xml:lang)'>
-        <xsl:attribute name='xml:lang'>
-          <xsl:value-of select='../@xml:lang'/>
-        </xsl:attribute>
-      </xsl:if>
       <xsl:attribute name='class'>content</xsl:attribute>
       <xsl:apply-templates select='@*|node()'/>
     </xsl:copy>
@@ -311,11 +286,6 @@
   <!-- plain text content -->
   <xsl:template match='atom:content/text() | atom:summary/text()'>
     <div class='content' xmlns='http://www.w3.org/1999/xhtml'>
-      <xsl:if test='../@xml:lang and not(../@xml:lang = ../../@xml:lang)'>
-        <xsl:attribute name='xml:lang'>
-          <xsl:value-of select='../@xml:lang'/>
-        </xsl:attribute>
-      </xsl:if>
       <xsl:copy-of select='.'/>
     </div>
   </xsl:template>


### PR DESCRIPTION
## Summary

The `mozilla.ini` site (the main Planet Mozilla page) generated invalid HTML. This fixes the validity errors at their source — the index template (`themes/mozilla/index.html.xslt`) and the search filter (`filters/addsearch.xslt`) — and restores the footer position that an earlier markup bug had been masking.

## Fixes

- **Stray `<?xml version="1.0"?>` before the doctype** — `addsearch.xslt` re-serialized the page with no `<xsl:output>`, so libxslt prepended an XML declaration (a forbidden processing instruction in a `text/html` document). Added `<xsl:output method="xml" omit-xml-declaration="yes" encoding="utf-8"/>`.
- **`<time datetime>` held literal XPath** — the value was the literal string `substring(atom:updated,1,10)` instead of a date. Wrapped it in `{…}` so it interpolates to e.g. `datetime="2026-02-09"`.
- **`href` on `<span class="label">`** — `href` isn't allowed on `<span>` and did nothing. Removed it.
- **Language attributes** — removed all per-element `xml:lang`/`lang` machinery. Non-English content isn't syndicated to Planet, so a single `lang="en-US"` on `<html>` covers the whole page. This also removes a broken XSLT 1.0 construct (`<xsl:attribute select="{…}"/>`) that emitted empty `xml:lang=""` attributes and dropped the actual title language.
- **Self-closing non-void elements** — removed the dead empty `<p/>` spacer and stopped the empty `<div class="bottom">` from self-closing.
- **Footer position** — `#footer` previously landed at the bottom of the sidebar only because the self-closing `<div class="bottom"/>` mis-parsed in `text/html` and swallowed a closing tag. With valid markup that quirk disappears, so `#footer` is now explicitly nested inside `.sidebar-content` to keep the same position rather than becoming a third flex column.

## Verification

All changes were verified by rendering the real `index.html.xslt → addsearch.xslt` filter chain through libxslt against a synthetic feed exercising each template branch. Confirmed: no stray XML declaration, doctype first, valid `datetime`, no `href` on span, no empty `xml:lang=""`, no self-closing non-void elements, a single `lang="en-US"`, and `#footer` nested inside `.sidebar-content` (two flex columns in `.main-container`).

Note: `output/` is a regenerated build artifact and is intentionally not included; regenerate it via the Docker flow before deploying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)