### PR TITLE
Bump dependencies to last Python 2.7-compatible versions (security)

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,14 @@ CacheControl
 argparse
 feedparser
 html5lib
-httplib2
+httplib2>=0.22.0
 lockfile
-pyOpenSSL
-requests
+pyOpenSSL>=21.0.0
+requests>=2.27.1
+
+# Security floors for transitive deps (last Python 2.7-compatible releases).
+# These are the newest versions installable on Python 2.7; the remaining
+# Dependabot alerts require Python 3 and cannot be resolved without migrating
+# Planet Venus off Python 2.7.
+cryptography>=3.3.2
+urllib3>=1.26.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,16 +10,17 @@ cachecontrol==0.12.5
 certifi==2019.6.16        # via requests
 cffi==1.12.3              # via cryptography
 chardet==3.0.4            # via requests
-cryptography==2.7         # via pyopenssl
+cryptography==3.3.2       # via pyopenssl ; last py2.7 release, fixes GHSA-hggm-jpg3-v476
 feedparser==5.2.1
 html5lib==1.0.1
-httplib2==0.13.0
+httplib2==0.22.0          # fixes GHSA-93xj-8mrv-444m, GHSA-gg84-qgv9-w4pq
 idna==2.8                 # via requests
 lockfile==0.12.2
 msgpack==0.6.1            # via cachecontrol
 pycparser==2.19           # via cffi
-pyopenssl==19.0.0
-requests==2.22.0
+pyparsing==2.4.7          # via httplib2 ; last py2.7 release
+pyopenssl==21.0.0         # last py2.7 release; required by cryptography>=3.3
+requests==2.27.1          # last py2.7 release; required to allow urllib3>=1.26
 six==1.12.0               # via cryptography, html5lib, pyopenssl
-urllib3==1.25.3           # via requests
+urllib3==1.26.20          # via requests ; last py2.7 release, fixes GHSA-v845/wqvq/34jh/g4mx/hmv2
 webencodings==0.5.1       # via html5lib


### PR DESCRIPTION
## Summary

Addresses the Dependabot alerts as far as the **Python 2.7** runtime allows. Of the 33 open alerts, this clears **8** by bumping each affected package to the newest release that still installs on Python 2.7. The other 25 are only patched in versions that require Python 3 and are out of reach without a runtime migration (see below).

## Changes

| Package | From | To | Why |
|---|---|---|---|
| cryptography | 2.7 | **3.3.2** | last py2.7 release; fixes `GHSA-hggm-jpg3-v476` |
| httplib2 | 0.13.0 | **0.22.0** | fixes `GHSA-93xj-8mrv-444m`, `GHSA-gg84-qgv9-w4pq` |
| urllib3 | 1.25.3 | **1.26.20** | last py2.7 release; fixes 5 alerts (`GHSA-v845`, `wqvq`, `34jh`, `g4mx`, `hmv2`) |
| pyOpenSSL | 19.0.0 | **21.0.0** | compatibility — `cryptography>=3.3` requires it |
| requests | 2.22.0 | **2.27.1** | compatibility — 2.22.0 caps `urllib3<1.26` |
| pyparsing | — | **2.4.7** | new transitive dep of httplib2 0.22.0 on py2 |

`requests` and `pyOpenSSL` are bumped purely to satisfy version constraints; they don't themselves clear alerts.

## Verification

Resolved and installed cleanly in a `python:2.7-slim` container (`pip install -r requirements.txt`, exit 0), then smoke-tested imports and the `pyOpenSSL` 21.0.0 ↔ `cryptography` 3.3.2 interop (TLS context creation + urllib3 pyOpenSSL/SNI injection both OK).

## What this does NOT fix (and why)

The remaining 25 alerts — `requests` 2.31+, `urllib3` 2.x, `idna` 3.x, `cryptography` 39–48, `msgpack` 1.2.1, `certifi` 2023+, `pyOpenSSL` 26 — only have fixes in versions that **require Python ≥3.9/3.10**. They cannot be installed on Python 2.7, so the only real remediation is migrating Planet Venus off the EOL Python 2.7 runtime.

**Risk context:** this is a build-time static-site generator. The Python runs in an ephemeral build container, makes outbound requests to a curated feed list, and emits static files; no Python executes at request time. The residual risk from the blocked alerts is low.

## Note

`requirements.txt` is normally `pip-compile` output but was edited by hand (pip-compile can't run in this environment). `requirements.in` records the security floors so a future recompile preserves them. Worth regenerating on a Python 2.7 env when convenient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)